### PR TITLE
Fix RFC-14 discussion thread link

### DIFF
--- a/vault/rfc.14-seed-bank.md
+++ b/vault/rfc.14-seed-bank.md
@@ -174,7 +174,7 @@ You can disable this behavior by setting [[addAttribution|rfc.14-seed-bank.confi
 
 ## Discussion
 
-All discussions and feedback should be left in this [discussion thread](https://wiki.dendron.so/notes/4039fc46-06b2-4f83-b817-fc490bafbcb3.html)
+All discussions and feedback should be left in this [discussion thread](https://github.com/dendronhq/dendron/discussions/802)
 
 ## TradeOffs
 


### PR DESCRIPTION
Directly linking to the discussion topic is probably good enough, as there is no link-rot-guarding link shortener service used for Dendron things that I know of. 

Note: I created this by clicking "Edit on Github", then accepting all the defaults for suggesting a change through a new fork (see `patch-1` branch name) to try this flow. Will follow up to check for contributor agreements and such 👍 