### PR TITLE
Add dev docs on deprecating existing config keys

### DIFF
--- a/vault/pkg.common-all.dev.cook.deprecating-existing-config.md
+++ b/vault/pkg.common-all.dev.cook.deprecating-existing-config.md
@@ -1,0 +1,13 @@
+---
+id: uznido7295nr7bh0x3h6hbp
+title: Deprecating Existing Config
+desc: ''
+updated: 1651082946506
+created: 1651082690760
+---
+
+Steps for deprecating an existing config:
+
+1. Scrub through the entire codebase that references the config key, and modify the logic accordingly.
+2. Add the deprecated path in [[../packages/engine-server/src/migrations/utils.ts#^2hgqigv11pvy]]
+3. Once the deprecated path is added, `ConfigUtils.detectDeprecatedConfigs` will catch it in the subsequent release (if `extensionInstallStatus === InstallStatus.UPGRADED`). The user will be prompted to trigger a doctor command. This means we don't have to explicitly write migration code that scrubs the deprecated config key from `dendron.yml`.

--- a/vault/pkg.common-all.dev.cook.md
+++ b/vault/pkg.common-all.dev.cook.md
@@ -2,7 +2,7 @@
 id: 1jIkH5R6W3pM8IYR2gOji
 title: Cookbook
 desc: ""
-updated: 1646420184133
+updated: 1651082957059
 created: 1634737110155
 ---
 
@@ -11,6 +11,10 @@ created: 1634737110155
 ### Add New Config
 
 ![[Add New Config|dendron://dendron.docs/pkg.common-all.dev.cook.add-new-config]]
+
+### Deprecating Existing Config
+
+![[Deprecating Existing Config|dendron://dendron.docs/pkg.common-all.dev.cook.deprecating-existing-config]]
 
 ### Accessing config values from `dendron.yml`
 


### PR DESCRIPTION
This PR:
- Adds instructions on how to deprecate existing config from `dendron.yml`
- Related to changes introduced in dendronhq/dendron#2841